### PR TITLE
chore: Update syntax to be compatible with k8s provider v2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -147,11 +147,11 @@ resource "kubernetes_stateful_set" "nfs_server" {
             name       = "${var.name}-nfs-backend"
           }
           resources {
-            requests {
+            requests = {
               cpu    = var.request_cpu
               memory = var.request_memory
             }
-            limits {
+            limits = {
               cpu    = var.limit_cpu
               memory = var.limit_memory
             }


### PR DESCRIPTION
Kubernetes provider v2 changed the syntax around resource requests and limits in StatefulSets to be more in line with k8s API